### PR TITLE
Added case destinction between Error and Warning

### DIFF
--- a/source-code-error.js
+++ b/source-code-error.js
@@ -67,21 +67,33 @@ module.exports = (options = {}) => {
             .replace(/(\n)(\s*\d+\s+\|)/g, (_, m1, m2) =>
                 m1 + chalk.grey(m2))
             .replace(/(\|\s*)(\^)/, (_, m1, m2) =>
-                chalk.grey(m1) + chalk.bold.red(m2))
+                (options.type === "WARNING") ? chalk.grey(m1) + chalk.bold.yellow(m2) : chalk.grey(m1) + chalk.bold.red(m2))
             .replace(/(\n)(>)(\s*\d+\s+\|)(.*)/, (_, m1, m2, m3, m4) =>
-                m1 + chalk.bold.red(m2) + chalk.grey(m3) + chalk.blue(m4))
+                (options.type === "WARNING") ? m1 + chalk.bold.yellow(m2) + chalk.grey(m3) + chalk.blue(m4) : m1 + chalk.bold.red(m2) + chalk.grey(m3) + chalk.blue(m4))
     }
 
     /*  generate header  */
     let header = ""
-    header += `${chalk.bold.red(options.type + ":")} `
-    if (options.filename !== "") {
-        const dirname = path.dirname(options.filename) + path.sep
-        const basename = path.basename(options.filename)
-        header += `${chalk.red("file \"")}${chalk.red(dirname)}${chalk.red.bold(basename)}${chalk.red("\", ")}`
+    if (options.type === "WARNING") {
+        header += `${chalk.bold.yellow(options.type + ":")} `
+        if (options.filename !== "") {
+            const dirname = path.dirname(options.filename) + path.sep
+            const basename = path.basename(options.filename)
+            header += `${chalk.yellow("file \"")}${chalk.yellow(dirname)}${chalk.yellow.bold(basename)}${chalk.yellow("\", ")}`
+        }
+        header += `${chalk.yellow("line ")}${chalk.yellow.bold(options.line)}` +
+            `${chalk.yellow(", column ")}${chalk.yellow.bold(options.column)}:\n`
     }
-    header += `${chalk.red("line ")}${chalk.red.bold(options.line)}` +
-        `${chalk.red(", column ")}${chalk.red.bold(options.column)}:\n`
+    else {
+        header += `${chalk.bold.red(options.type + ":")} `
+        if (options.filename !== "") {
+            const dirname = path.dirname(options.filename) + path.sep
+            const basename = path.basename(options.filename)
+            header += `${chalk.red("file \"")}${chalk.red(dirname)}${chalk.red.bold(basename)}${chalk.red("\", ")}`
+        }
+        header += `${chalk.red("line ")}${chalk.red.bold(options.line)}` +
+            `${chalk.red(", column ")}${chalk.red.bold(options.column)}:\n`
+    }
     if (options.message !== "" || options.origin !== "") {
         header += " ".repeat(options.type.length + 2)
         if (options.message !== "")


### PR DESCRIPTION
A visual distinction between warnings (yellow) and errors (red) is useful to quickly and intuitively understand an output's meaning.

Since options.type can be any string and not just "ERROR" or "WARNING", an if-block was added to check if type.options equals "WARNING" that changes the output color from red to yellow. If not, the "default case" is triggered and the output color remains red. If further color distinction become necessary in the future, additional elifs can be added.